### PR TITLE
Fix Flutter 3.7 compatibility issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  modal_bottom_sheet: ^2.0.0
+  modal_bottom_sheet: ^3.0.0-pre
   collection: ^1.15.0
   universal_platform: ^1.0.0+1
 


### PR DESCRIPTION
Bump modal_bottom_sheet to `3.0.0-pre`